### PR TITLE
fix: replace deprecated --highlight-style pandoc flag

### DIFF
--- a/book/build_pdf.sh
+++ b/book/build_pdf.sh
@@ -55,7 +55,7 @@ pandoc "${CHAPTERS[@]}" \
     --metadata author-meta="李博杰" \
     -H preamble.tex \
     --include-before-body=cover.tex \
-    --highlight-style=kate \
+    --syntax-highlighting=kate \
     --columns=80 \
     2>&1
 


### PR DESCRIPTION
## Summary
- `build_pdf.sh` triggered a pandoc deprecation warning: `--highlight-style` is deprecated in favor of `--syntax-highlighting`.
- Swap the flag; behavior is unchanged (same `kate` style).

## Test plan
- [x] Ran `bash build_pdf.sh` — deprecation warning no longer appears (build now proceeds past flag parsing straight to the `xelatex` step, which isn't installed in this sandbox).