### PR TITLE
fix(chapter1/context): load .env in main.py so API keys are available

### DIFF
--- a/chapter1/context/main.py
+++ b/chapter1/context/main.py
@@ -27,6 +27,15 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+# Load .env so API keys configured there are available via os.getenv.
+# (config.py calls load_dotenv() too, but main.py only imports agent, which
+#  does not import config, so we must trigger it here.)
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 
 class AblationTestSuite:
     """Test suite for exploring context importance through ablation studies"""


### PR DESCRIPTION
main.py only imported agent (which does not import config), so the load_dotenv() call in config.py never executed on the CLI path. As a result os.getenv('SILICONFLOW_API_KEY') and friends returned empty and the program aborted with 'No API key found' even when .env was correctly configured.

Call load_dotenv() at startup in main.py so all run modes (ablation/single/ interactive) can read provider keys set in .env.